### PR TITLE
Don't teach anti-patterns :)

### DIFF
--- a/slides/090-webcomponents/CounterExample.js
+++ b/slides/090-webcomponents/CounterExample.js
@@ -1,8 +1,7 @@
 import { State, Computed, Effect } from './signals.js';
 
 export class CounterExample extends HTMLElement {
-  constructor() {
-    super()
+  connectedCallback() {
     this.attachShadow({mode: 'open'})
     this.shadowRoot.innerHTML = `
       <p>Count: <span id="count"></span></p>


### PR DESCRIPTION
In Custom elements, [it is discouraged](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks) to do any work with DOM in element `constructor`. This work should be done in `connectedCallback` method.